### PR TITLE
cmake: remove manual specification of -O2 -g

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,9 +87,9 @@ add_executable(vltrace ${SOURCES} ${TXT_OBJS})
 # XXX libbcc expects multi-treading safety. Currently it's required for
 # print_event_cb.o only, although we will apply it for overall application.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -D_GNU_SOURCE")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
 # using Clang

--- a/src/ebpf/CMakeLists.txt
+++ b/src/ebpf/CMakeLists.txt
@@ -85,6 +85,6 @@ set_target_properties(ebpf PROPERTIES
 # XXX libbcc expects multi-treading safety. Currently it's required for
 # print_event_cb.o only, although we will apply it for overall application.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -D_GNU_SOURCE")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")


### PR DESCRIPTION
Let cmake handle this.
Since these flags were added in any build, the resulting builds
ended up being optimized with "-O2" even in Debug configuration.
Removing -O2 can make debugging more pleasent.